### PR TITLE
Add publishing timestamp message to service summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,18 @@ proxies: # Top-level proxy settings
     
     - **Note:** Similarly, a prefix can also be specified using `service_prefix`.
 
-**Note:** By default, backups are created when publishing MapServer and GeocodeServer services. A `Backups` subdirectory is created in the same directory as the source file(s), and a copy of the services to be published are placed there with a timestamp appended. To disable creating backups, pass the `create_backups=False` argument.
+#### Additional arguments
+
+- `create_backups`: By default, backups are created when publishing MapServer and GeocodeServer services.
+
+    A `Backups` subdirectory is created in the same directory as the source file(s), and a copy of the services to be published are placed there with a timestamp appended.
+    
+    To disable creating backups, pass the `create_backups=False` argument.
+- `update_timestamps`: By default, when a service is successfully published, the `summary` field of the service is updated with a message including the publisher's username and the date and time of publishing.
+
+    This requires a valid [ArcGIS Admin REST API token][5] be set for each ArcGIS Server instance being published to (see the ["Generate tokens"](#generate-tokens) section  below for more details).
+    
+    To disable updating timestamps, pass the `update_timestamps=False` argument.
 
 ### Clean up services
 

--- a/ags_service_publisher/ags_utils.py
+++ b/ags_service_publisher/ags_utils.py
@@ -272,6 +272,103 @@ def get_service_info(server_url, token, service_name, service_folder=None, servi
         raise
 
 
+def get_service_item_info(server_url, token, service_name, service_folder=None, service_type='MapServer', session=None):
+    log.debug('Getting item info for service {} (URL {}, Folder: {})'.format(service_name, server_url, service_folder))
+    url = urljoin(
+        server_url,
+        '/'.join(
+            (
+                part for part in (
+                    '/arcgis/admin/services',
+                    service_folder,
+                    '{}.{}'.format(service_name, service_type),
+                    'iteminfo'
+                ) if part
+            )
+        )
+    )
+    try:
+        r = session.post(url, params={'f': 'json'}, data={'token': token})
+        log.debug('Request URL: {}'. format(r.url))
+        assert (r.status_code == 200)
+        data = r.json()
+        if data.get('status') == 'error':
+            raise RuntimeError(data.get('messages'))
+        if data.get('error'):
+            raise RuntimeError(data.get('error').get('message'))
+        log.debug(
+            'Service {} item info (URL {}, Folder: {}): {}'
+            .format(service_name, server_url, service_folder, json.dumps(data, indent=4))
+        )
+        return data
+    except StandardError:
+        log.exception(
+            'An error occurred while getting item info for service {}/{}'
+            .format(service_folder, service_name)
+        )
+        raise
+
+
+def set_service_item_info(server_url, token, item_info, service_name, service_folder=None, service_type='MapServer', session=None):
+    log.debug('Setting item info for service {} (URL {}, Folder: {})'.format(service_name, server_url, service_folder))
+    url = urljoin(
+        server_url,
+        '/'.join(
+            (
+                part for part in (
+                    '/arcgis/admin/services',
+                    service_folder,
+                    '{}.{}'.format(service_name, service_type),
+                    'iteminfo/edit'
+                ) if part
+            )
+        )
+    )
+    try:
+        r = session.post(
+            url,
+            params={
+                'f': 'json'
+            },
+            data={'token': token},
+            files=[
+                (
+                    'serviceItemInfo',
+                    (
+                        None,
+                        json.dumps(item_info)
+                    )
+                ),
+                (
+                    'thumbnail',
+                    (
+                        '',
+                        None,
+                        'application/octet-stream'
+                    )
+                )
+            ]
+        )
+        log.debug('Request URL: {}'.format(r.url))
+        assert (r.status_code == 200)
+        data = r.json()
+        if data.get('status') == 'error':
+            raise RuntimeError(data.get('messages'))
+        if data.get('error'):
+            raise RuntimeError(data.get('error').get('message'))
+        log.debug(
+            'Updated service {} item info (URL {}, Folder: {}): {}'
+            .format(service_name, server_url, service_folder, json.dumps(data, indent=4))
+        )
+        return data
+    except StandardError:
+        log.exception(
+            'An error occurred while setting item info for service {}/{}'
+            .format(service_folder, service_name)
+        )
+        raise
+
+
 def get_service_manifest(server_url, token, service_name, service_folder=None, service_type='MapServer', session=None):
     log.debug('Getting manifest for service {} (URL {}, Folder: {})'.format(service_name, server_url, service_folder))
     url = urljoin(

--- a/ags_service_publisher/ags_utils.py
+++ b/ags_service_publisher/ags_utils.py
@@ -18,6 +18,7 @@ from logging_io import setup_logger
 
 log = setup_logger(__name__)
 
+
 def create_session(server_url, proxies=None):
     session = requests.Session()
     if proxies:
@@ -25,6 +26,7 @@ def create_session(server_url, proxies=None):
     adapter = SSLContextAdapter()
     session.mount(server_url, adapter)
     return session
+
 
 def generate_token(server_url, username=None, password=None, expiration=15, ags_instance=None, session=None):
     username, password = prompt_for_credentials(username, password, ags_instance)
@@ -648,7 +650,7 @@ def restart_service(
         log.info(
             'Restarting service {} (URL {}, Folder: {}, attempt #{} of {})'
             .format(service_name, server_url, service_folder, retry_count, max_retries)
-         )
+        )
         stop_service(server_url, token, service_name, service_folder, service_type, session=session)
         log.debug(
             'Waiting {} seconds before restarting service {} (URL {}, Folder: {})'
@@ -774,6 +776,7 @@ def import_sde_connection_file(ags_connection_file, sde_connection_file):
                 .format(sde_connection_file, ags_connection_file)
             )
             raise
+
 
 # Adapted from https://stackoverflow.com/a/50215614
 class SSLContextAdapter(HTTPAdapter):

--- a/ags_service_publisher/config_io.py
+++ b/ags_service_publisher/config_io.py
@@ -88,4 +88,3 @@ def write_config_to_file(config, file_path):
     log.debug('Writing config to file: {}'.format(file_path))
     with open(file_path, 'wb') as f:
         ordered_dump(config, f, default_flow_style=False, width=float('inf'))
-

--- a/ags_service_publisher/publishing.py
+++ b/ags_service_publisher/publishing.py
@@ -178,7 +178,15 @@ def publish_env(
             create_backups
         ):
             if result['succeeded'] and update_timestamps:
-                set_publishing_summary(user_config, env_name, result)
+                set_publishing_summary(
+                    user_config,
+                    env_name,
+                    result['ags_instance'],
+                    result['service_name'],
+                    result['service_folder'],
+                    result['service_type'],
+                    result['timestamp']
+                )
             yield result
     finally:
         restore_site_modes(ags_instances, env_name, user_config, initial_site_modes)
@@ -188,9 +196,17 @@ def publish_env(
             cleanup_instance(ags_instance, env_name, config, user_config)
 
 
-def set_publishing_summary(user_config, env_name, result):
+def set_publishing_summary(
+    user_config,
+    env_name,
+    ags_instance,
+    service_name,
+    service_folder,
+    service_type,
+    timestamp
+):
     try:
-        ags_instance_props = user_config['environments'][env_name]['ags_instances'][result['ags_instance']]
+        ags_instance_props = user_config['environments'][env_name]['ags_instances'][ags_instance]
         server_url = ags_instance_props['url']
         token = ags_instance_props['token']
         proxies = ags_instance_props.get('proxies') or user_config.get('proxies')
@@ -198,31 +214,31 @@ def set_publishing_summary(user_config, env_name, result):
             item_info = get_service_item_info(
                 server_url,
                 token,
-                result['service_name'],
-                result['service_folder'],
-                result['service_type'],
+                service_name,
+                service_folder,
+                service_type,
                 session=session
             )
             item_info['summary'] = 'Last published by {} on {:%#m/%#d/%y at %#I:%M:%S %p}'.format(
                 getpass.getuser(),
-                result['timestamp']
+                timestamp
             )
             set_service_item_info(
                 server_url,
                 token,
                 item_info,
-                result['service_name'],
-                result['service_folder'],
-                result['service_type'],
+                service_name,
+                service_folder,
+                service_type,
                 session=session
             )
     except StandardError:
         log.warning(
             'An error occurred while updating timestamp for service {}/{} to ArcGIS Server instance {}'
             .format(
-                result['service_folder'],
-                result['service_name'],
-                result['ags_instance']
+                service_folder,
+                service_name,
+                ags_instance
             ),
             exc_info=True
         )

--- a/ags_service_publisher/publishing.py
+++ b/ags_service_publisher/publishing.py
@@ -177,7 +177,7 @@ def publish_env(
             warn_on_publishing_errors,
             create_backups
         ):
-            if result['succeeded'] and update_timestamps:
+            if update_timestamps and result['succeeded']:
                 set_publishing_summary(
                     user_config,
                     env_name,

--- a/ags_service_publisher/runner.py
+++ b/ags_service_publisher/runner.py
@@ -66,7 +66,8 @@ class Runner:
         service_suffix='',
         warn_on_publishing_errors=False,
         warn_on_validation_errors=False,
-        create_backups=True
+        create_backups=True,
+        update_timestamps=True
     ):
         configs = get_configs(included_configs, excluded_configs, self.config_dir)
         log.info('Batch publishing configs: {}'.format(', '.join(config_name for config_name in configs.keys())))
@@ -87,7 +88,8 @@ class Runner:
                         service_suffix,
                         warn_on_publishing_errors,
                         warn_on_validation_errors,
-                        create_backups
+                        create_backups,
+                        update_timestamps
                     ):
                         result['config_name'] = config_name
                         yield result


### PR DESCRIPTION
Adds a message including the publisher's username and the date and time of publishing to the service's [item information](https://developers.arcgis.com/rest/enterprise-administration/server/iteminfo.htm) `summary` field when a service is successfully published. This appears in Manager so that you can see at a glance when and by whom a service was last published:

![ec6921dd-e0f6-4846-ae44-b7ce2243d0ef](https://user-images.githubusercontent.com/8584785/73312829-48a54000-41ef-11ea-9c0c-11a362a21261.png)


- Enabled by default, can be disabled by passing `update_timestamps=False` to the `run_batch_publishing_job` or related publishing functions.
- Requires [Admin REST API tokens](https://developers.arcgis.com/rest/enterprise-administration/server/apisecurity.htm) to be configured in order for the summary field to be updated, but will not raise an error if a configuration issue or other error occurs while updating the field (allowing publishing to proceed normally; exceptions will be logged as a warning).